### PR TITLE
feat: add multi-template school site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-nuxt 3
+# Nuxt Web School
+
+Contoh struktur proyek Nuxt 3 untuk website sekolah dengan dukungan beberapa template.
+
+## Fitur
+- Struktur menu utama dan sub menu pada `common/menu.ts`.
+- Plugin `plugins/fetchTheme.ts` memuat tema aktif dari endpoint backend `/theme`.
+- Store pada `store/index.ts` menyimpan metadata sekolah dan tema.
+- Layout global `layouts/default.vue` memuat layout sesuai tema yang dipilih.
+- Setiap template memiliki layout tersendiri pada `templates/template*/layouts/DefaultLayout.vue`.
+
+## Pengembangan
+```
+npm install
+npm run dev
+```

--- a/common/menu.ts
+++ b/common/menu.ts
@@ -1,0 +1,40 @@
+export interface MenuItem {
+  label: string;
+  path: string;
+  children?: MenuItem[];
+}
+
+export const mainMenu: MenuItem[] = [
+  { label: 'Beranda', path: '/' },
+  {
+    label: 'Profil',
+    path: '/profil',
+    children: [
+      { label: 'Sambutan', path: '/profil/sambutan' },
+      { label: 'Pimpinan', path: '/profil/pimpinan' },
+      { label: 'Tenaga Pendidikan', path: '/profil/tenaga-pendidikan' },
+      { label: 'Staff', path: '/profil/staff' },
+    ],
+  },
+  { label: 'Jurusan', path: '/jurusan' },
+  { label: 'Ekstrakurikuler', path: '/ekstrakurikuler' },
+  {
+    label: 'Informasi',
+    path: '/informasi',
+    children: [
+      { label: 'Berita', path: '/informasi/berita' },
+      { label: 'Pengumuman', path: '/informasi/pengumuman' },
+    ],
+  },
+  {
+    label: 'Biro dan Lembaga',
+    path: '/biro',
+    children: [
+      { label: 'Manajemen Mutu', path: '/biro/manajemen-mutu' },
+      { label: 'Bursa Kerja Siswa', path: '/biro/bursa-kerja' },
+      { label: 'LSP', path: '/biro/lsp' },
+    ],
+  },
+  { label: 'PPDB', path: '/ppdb' },
+  { label: 'Kontak', path: '/kontak' },
+];

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,16 @@
+<template>
+  <component :is="layoutComponent">
+    <slot />
+  </component>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {
+    layoutComponent() {
+      const theme = this.$store.state.metaData?.theme?.name || 'template1';
+      return () => import(`~/templates/${theme}/layouts/DefaultLayout.vue`);
+    },
+  },
+};
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,8 @@
+import { defineNuxtConfig } from 'nuxt';
+
+export default defineNuxtConfig({
+  modules: [],
+  typescript: {
+    strict: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt-webschool",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "nuxt": "^3.0.0"
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Beranda</h1>
+  </div>
+</template>

--- a/plugins/fetchTheme.ts
+++ b/plugins/fetchTheme.ts
@@ -1,0 +1,6 @@
+import { MetaData } from '~/types';
+
+export default async ({ $axios, store }) => {
+  const { data } = await $axios.get<MetaData>('/theme');
+  store.commit('setMetaData', data);
+};

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,0 +1,11 @@
+import type { MetaData } from '~/types';
+
+export const state = () => ({
+  metaData: null as MetaData | null,
+});
+
+export const mutations = {
+  setMetaData(state: { metaData: MetaData | null }, payload: MetaData) {
+    state.metaData = payload;
+  },
+};

--- a/templates/template1/layouts/DefaultLayout.vue
+++ b/templates/template1/layouts/DefaultLayout.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <nav>
+      <ul>
+        <li v-for="item in menu" :key="item.path">
+          <a :href="item.path">{{ item.label }}</a>
+        </li>
+      </ul>
+    </nav>
+    <main>
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script lang="ts">
+import { mainMenu } from '~/common/menu';
+
+export default {
+  data() {
+    return { menu: mainMenu };
+  },
+};
+</script>

--- a/templates/template2/layouts/DefaultLayout.vue
+++ b/templates/template2/layouts/DefaultLayout.vue
@@ -1,0 +1,24 @@
+<template>
+  <div style="display:flex;">
+    <aside style="width:200px;">
+      <ul>
+        <li v-for="item in menu" :key="item.path">
+          <a :href="item.path">{{ item.label }}</a>
+        </li>
+      </ul>
+    </aside>
+    <section style="flex:1;">
+      <slot />
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+import { mainMenu } from '~/common/menu';
+
+export default {
+  data() {
+    return { menu: mainMenu };
+  },
+};
+</script>

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,10 @@
+export interface ThemeInterface {
+  id: number;
+  name: string;
+  previews: Record<string, any>[];
+}
+
+export interface MetaData {
+  school: Record<string, any>;
+  theme: ThemeInterface;
+}


### PR DESCRIPTION
## Summary
- add menu definitions for school site
- implement theme-fetching plugin and store
- provide two example templates and dynamic layout loader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be56726c008322bf743f36b686be9e